### PR TITLE
MB-47438: DocIDReader cannot return EOF when done

### DIFF
--- a/docid.go
+++ b/docid.go
@@ -16,7 +16,6 @@ package sear
 
 import (
 	"bytes"
-	"io"
 
 	index "github.com/blevesearch/bleve_index_api"
 )
@@ -39,7 +38,7 @@ func NewDocIDReader() *DocIDReader {
 
 func (d *DocIDReader) Next() (index.IndexInternalID, error) {
 	if d.done {
-		return nil, io.EOF
+		return nil, nil
 	}
 	d.done = true
 	return internalDocID, nil
@@ -47,12 +46,12 @@ func (d *DocIDReader) Next() (index.IndexInternalID, error) {
 
 func (d *DocIDReader) Advance(id index.IndexInternalID) (index.IndexInternalID, error) {
 	if d.done {
-		return nil, io.EOF
+		return nil, nil
 	}
 	if bytes.Compare(id, internalDocID) > 0 {
 		// seek is after our internal id
 		d.done = true
-		return nil, io.EOF
+		return nil, nil
 	}
 	return d.Next()
 }

--- a/docid_test.go
+++ b/docid_test.go
@@ -16,7 +16,6 @@ package sear
 
 import (
 	"bytes"
-	"io"
 	"testing"
 
 	index "github.com/blevesearch/bleve_index_api"
@@ -26,13 +25,13 @@ func TestDocIDReader(t *testing.T) {
 	// first test empty
 	var docIDReader *DocIDReader = docIDReaderEmpty
 	_, err := docIDReader.Next()
-	if err != io.EOF {
-		t.Fatalf("expected eof")
+	if err != nil {
+		t.Fatalf("expected nil")
 	}
 
 	_, err = docIDReader.Advance(internalDocID)
-	if err != io.EOF {
-		t.Fatalf("expected eof")
+	if err != nil {
+		t.Fatalf("expected nil")
 	}
 
 	// now test non-empty with no advance
@@ -46,9 +45,9 @@ func TestDocIDReader(t *testing.T) {
 		t.Fatalf("expected %v, got %v", internalDocID, internal)
 	}
 
-	_, err = docIDReader.Next()
-	if err != io.EOF {
-		t.Errorf("expected eof")
+	internal, err = docIDReader.Next()
+	if err != nil || internal != nil {
+		t.Errorf("expected nils")
 	}
 
 	// test empty again with advance
@@ -61,16 +60,16 @@ func TestDocIDReader(t *testing.T) {
 		t.Fatalf("expected %v, got %v", internalDocID, internal)
 	}
 
-	_, err = docIDReader.Next()
-	if err != io.EOF {
-		t.Errorf("expected eof")
+	internal, err = docIDReader.Next()
+	if err != nil || internal != nil {
+		t.Errorf("unexpected err: %v, internal: %v", err, internal)
 	}
 
 	// test empty again with advance to other internal id
 	docIDReader = NewDocIDReader()
-	_, err = docIDReader.Advance([]byte{0x1})
-	if err != io.EOF {
-		t.Errorf("expected eof")
+	internal, err = docIDReader.Advance([]byte{0x1})
+	if err != nil || internal != nil {
+		t.Errorf("unexpected err: %v, internal: %v", err, internal)
 	}
 
 	err = docIDReader.Close()

--- a/index_test.go
+++ b/index_test.go
@@ -16,7 +16,6 @@ package sear
 
 import (
 	"bytes"
-	"io"
 	"reflect"
 	"strings"
 	"testing"
@@ -385,9 +384,6 @@ func assertDocIDReader(t *testing.T, reader index.DocIDReader, expected [][]byte
 	for err == nil && internalID != nil {
 		internalIdsSeen = append(internalIdsSeen, internalID)
 		internalID, err = reader.Next()
-	}
-	if err != io.EOF {
-		t.Fatalf("unexpected error getting all doc ids")
 	}
 	if !reflect.DeepEqual(expected, internalIdsSeen) {
 		t.Fatalf("expected: %v, got %v", expected, internalIdsSeen)


### PR DESCRIPTION
+ This would inadvertantly cause a compound searcher
  like a boolean searcher to exit early before returning
  the results.
+ Test case catching the issue here -
    http://review.couchbase.org/c/n1fty/+/157714