### PR TITLE
MB-47473: Iterate over byte array while determining an automaton match

### DIFF
--- a/index_test.go
+++ b/index_test.go
@@ -665,6 +665,30 @@ func TestMB47265(t *testing.T) {
 	}
 }
 
+func TestMB47473(t *testing.T) {
+	idx, err := New("", nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mapAndUpdateDocument(t, idx, "bleve", map[string]interface{}{
+		"title": "Bleve",
+		"body":  []string{"ko", "kó"},
+	})
+
+	reader, err := idx.Reader()
+	if err != nil {
+		t.Fatalf("error getting index reader: %v", err)
+	}
+
+	readerRegexp := reader.(index.IndexReaderRegexp)
+	fd, err := readerRegexp.FieldDictRegexp("body", "k.*")
+	if err != nil {
+		t.Fatalf("error getting field dictionary range: %v", err)
+	}
+	assertTermDictionary(t, fd, []string{"ko", "kó"})
+}
+
 func createBenchmarkIndexReader(b *testing.B) index.IndexReader {
 	idx, err := New("", nil, nil)
 	if err != nil {

--- a/reader.go
+++ b/reader.go
@@ -139,7 +139,7 @@ func (r *Reader) FieldDictPrefix(field string, termPrefix []byte) (index.FieldDi
 
 func automatonMatch(la vellum.Automaton, termStr string) bool {
 	state := la.Start()
-	for i := range termStr {
+	for i := range []byte(termStr) {
 		state = la.Accept(state, termStr[i])
 		if !la.CanMatch(state) {
 			return false


### PR DESCRIPTION
+ Iterate over the byte array of a term (string) to correctly
  determine the positions of `diacritics` while evaluating terms
  that qualify a regular expression.