### PR TITLE
MB-59863: Vector validation, compliant to bleve_index_api@v1.1.4

### DIFF
--- a/.github/workflows/cover.yml
+++ b/.github/workflows/cover.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: '1.18.x'
+          go-version: '1.20.x'
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.18.x, 1.19.x]
+        go-version: [1.19.x, 1.20.x, 1.21.x]
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/doc.go
+++ b/doc.go
@@ -29,11 +29,10 @@ type Document struct {
 	fieldNames      []string
 	fieldTokenFreqs []index.TokenFrequencies
 	fieldLens       []int
+	vectorDims      []int // applicable to vector fields only
 
 	// deferred build and cache
 	sortedTerms map[string][]string
-
-	vectorDims []int
 }
 
 func NewDocument() *Document {

--- a/doc.go
+++ b/doc.go
@@ -102,6 +102,7 @@ func (d *Document) Reset(doc index.Document) {
 	d.fieldNames = d.fieldNames[:0]
 	d.fieldTokenFreqs = d.fieldTokenFreqs[:0]
 	d.fieldLens = d.fieldLens[:0]
+	d.vectorDims = d.vectorDims[:0]
 
 	// clear cache
 	for k := range d.sortedTerms {

--- a/doc.go
+++ b/doc.go
@@ -32,6 +32,8 @@ type Document struct {
 
 	// deferred build and cache
 	sortedTerms map[string][]string
+
+	vectorDims []int
 }
 
 func NewDocument() *Document {
@@ -65,6 +67,7 @@ func (d *Document) newField(field index.Field) {
 		d.fieldNames = append(d.fieldNames, field.Name())
 		d.fieldTokenFreqs = append(d.fieldTokenFreqs, af)
 		d.fieldLens = append(d.fieldLens, field.AnalyzedLength())
+		d.vectorDims = append(d.vectorDims, d.interpretVectorIfApplicable(field))
 	} else {
 		d.fieldTokenFreqs[fieldIdx].MergeAll(field.Name(), af)
 		d.fieldLens[fieldIdx] += field.AnalyzedLength()
@@ -141,4 +144,13 @@ func (d *Document) TokenFreqsAndLen(fieldName string) (index.TokenFrequencies, i
 		return nil, 0, err
 	}
 	return d.fieldTokenFreqs[fieldIdx], d.fieldLens[fieldIdx], nil
+}
+
+func (d *Document) VectorDims(fieldName string) (dims int, err error) {
+	fieldIdx, err := d.fieldIndex(fieldName)
+	if err != nil {
+		return 0, err
+	}
+
+	return d.vectorDims[fieldIdx], nil
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/blevesearch/sear
 
-go 1.18
+go 1.20
 
 require (
 	github.com/blevesearch/bleve_index_api v1.1.3

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/blevesearch/sear
 go 1.18
 
 require (
-	github.com/blevesearch/bleve_index_api v1.0.5
+	github.com/blevesearch/bleve_index_api v1.1.3
 	github.com/blevesearch/vellum v1.0.9
 )
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/blevesearch/sear
 go 1.20
 
 require (
-	github.com/blevesearch/bleve_index_api v1.1.3
+	github.com/blevesearch/bleve_index_api v1.1.4
 	github.com/blevesearch/vellum v1.0.9
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/bits-and-blooms/bitset v1.2.0 h1:Kn4yilvwNtMACtf1eYDlG8H77R07mZSPbMjLyS07ChA=
 github.com/bits-and-blooms/bitset v1.2.0/go.mod h1:gIdJ4wp64HaoK2YrL1Q5/N7Y16edYb8uY+O0FJTyyDA=
-github.com/blevesearch/bleve_index_api v1.1.3 h1:aNyMEiWFviY/1zYm7JCr2lZRIiYX0TMtz3oymxxbApc=
-github.com/blevesearch/bleve_index_api v1.1.3/go.mod h1:PbcwjIcRmjhGbkS/lJCpfgVSMROV6TRubGGAODaK1W8=
+github.com/blevesearch/bleve_index_api v1.1.4 h1:n9Ilxlb80g9DAhchR95IcVrzohamDSri0wPnkKnva50=
+github.com/blevesearch/bleve_index_api v1.1.4/go.mod h1:PbcwjIcRmjhGbkS/lJCpfgVSMROV6TRubGGAODaK1W8=
 github.com/blevesearch/mmap-go v1.0.4 h1:OVhDhT5B/M1HNPpYPBKIEJaD0F3Si+CrEKULGCDPWmc=
 github.com/blevesearch/mmap-go v1.0.4/go.mod h1:EWmEAOmdAS9z/pi/+Toxu99DnsbhG1TIxUoRmJw/pSs=
 github.com/blevesearch/vellum v1.0.9 h1:PL+NWVk3dDGPCV0hoDu9XLLJgqU4E5s/dOeEJByQ2uQ=

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/bits-and-blooms/bitset v1.2.0 h1:Kn4yilvwNtMACtf1eYDlG8H77R07mZSPbMjLyS07ChA=
 github.com/bits-and-blooms/bitset v1.2.0/go.mod h1:gIdJ4wp64HaoK2YrL1Q5/N7Y16edYb8uY+O0FJTyyDA=
-github.com/blevesearch/bleve_index_api v1.0.5 h1:Lc986kpC4Z0/n1g3gg8ul7H+lxgOQPcXb9SxvQGu+tw=
-github.com/blevesearch/bleve_index_api v1.0.5/go.mod h1:YXMDwaXFFXwncRS8UobWs7nvo0DmusriM1nztTlj1ms=
+github.com/blevesearch/bleve_index_api v1.1.3 h1:aNyMEiWFviY/1zYm7JCr2lZRIiYX0TMtz3oymxxbApc=
+github.com/blevesearch/bleve_index_api v1.1.3/go.mod h1:PbcwjIcRmjhGbkS/lJCpfgVSMROV6TRubGGAODaK1W8=
 github.com/blevesearch/mmap-go v1.0.4 h1:OVhDhT5B/M1HNPpYPBKIEJaD0F3Si+CrEKULGCDPWmc=
 github.com/blevesearch/mmap-go v1.0.4/go.mod h1:EWmEAOmdAS9z/pi/+Toxu99DnsbhG1TIxUoRmJw/pSs=
 github.com/blevesearch/vellum v1.0.9 h1:PL+NWVk3dDGPCV0hoDu9XLLJgqU4E5s/dOeEJByQ2uQ=

--- a/vector.go
+++ b/vector.go
@@ -44,7 +44,7 @@ func (r *Reader) VectorReader(ctx context.Context, vector []float32,
 		return NewVectorFieldReaderEmpty(), nil
 	}
 
-	if dims != len(vector) {
+	if k == 0 || dims != len(vector) {
 		// no match
 		return NewVectorFieldReaderEmpty(), nil
 	}

--- a/vector.go
+++ b/vector.go
@@ -32,7 +32,7 @@ func (d *Document) interpretVectorIfApplicable(field index.Field) int {
 	return 0
 }
 
-func (r *Reader) VectorIndexReader(ctx context.Context, vector []float32,
+func (r *Reader) VectorReader(ctx context.Context, vector []float32,
 	field string, k int64) (index.VectorReader, error) {
 	if r.s.doc == nil {
 		return NewVectorFieldReaderEmpty(), nil

--- a/vector.go
+++ b/vector.go
@@ -1,0 +1,113 @@
+//  Copyright (c) 2023 Couchbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//              http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build vectors
+// +build vectors
+
+package sear
+
+import (
+	"bytes"
+	"context"
+
+	index "github.com/blevesearch/bleve_index_api"
+)
+
+func (d *Document) interpretVectorIfApplicable(field index.Field) int {
+	if vf, ok := field.(index.VectorField); ok {
+		return vf.Dims()
+	}
+
+	return 0
+}
+
+func (r *Reader) VectorIndexReader(ctx context.Context, vector []float32,
+	field string, k int64) (index.VectorReader, error) {
+	if r.s.doc == nil {
+		return NewVectorFieldReaderEmpty(), nil
+	}
+
+	dims, err := r.s.doc.VectorDims(field)
+	if err != nil {
+		// only error is field doesn't exist in doc
+		return NewVectorFieldReaderEmpty(), nil
+	}
+
+	if dims != len(vector) {
+		// no match
+		return NewVectorFieldReaderEmpty(), nil
+	}
+
+	return NewVectorFieldReaderMatch(dims), nil
+
+}
+
+// -----------------------------------------------------------------------------
+
+type VectorFieldReader struct {
+	done bool
+	dims int
+}
+
+func NewVectorFieldReaderEmpty() *VectorFieldReader {
+	return &VectorFieldReader{
+		done: true,
+	}
+}
+
+func NewVectorFieldReaderMatch(dims int) *VectorFieldReader {
+	return &VectorFieldReader{
+		dims: dims,
+	}
+}
+
+func (v *VectorFieldReader) Next(preAlloced *index.VectorDoc) (*index.VectorDoc, error) {
+	if v.done {
+		return nil, nil
+	}
+	rv := preAlloced
+	if rv == nil {
+		rv = &index.VectorDoc{}
+	}
+	rv.ID = internalDocID
+	v.done = true
+	return rv, nil
+}
+
+func (v *VectorFieldReader) Advance(id index.IndexInternalID, preAlloced *index.VectorDoc) (*index.VectorDoc, error) {
+	if v.done {
+		return nil, nil
+	}
+	if bytes.Compare(id, internalDocID) > 0 {
+		// seek is after our internal id
+		v.done = true
+		return nil, nil
+	}
+	return v.Next(preAlloced)
+}
+
+func (v *VectorFieldReader) Count() uint64 {
+	if v.dims != 0 {
+		return 1
+	}
+	return 0
+}
+
+func (v *VectorFieldReader) Close() error {
+	return nil
+}
+
+func (v *VectorFieldReader) Size() int {
+	return 0
+}

--- a/vector_nosup.go
+++ b/vector_nosup.go
@@ -1,0 +1,27 @@
+//  Copyright (c) 2023 Couchbase, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//              http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !vectors
+// +build !vectors
+
+package sear
+
+import (
+	index "github.com/blevesearch/bleve_index_api"
+)
+
+func (d *Document) interpretVectorIfApplicable(field index.Field) int {
+	// not applicable
+	return 0
+}


### PR DESCRIPTION
Given that sear can only ever hold a single document, the VectorReader here will only
make sure that the field is available in the document and that the dimensions set for it
matches that of the query vector.