### PR TITLE
MB-62230: Update VectorIndexReader interface compliant to bleve_index_api@v1.1.12

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.19.x, 1.20.x, 1.21.x]
+        go-version: [1.20.x, 1.21.x, 1.22.x]
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,9 @@
 module github.com/blevesearch/sear
 
-go 1.20
+go 1.21
 
 require (
-	github.com/blevesearch/bleve_index_api v1.1.11
+	github.com/blevesearch/bleve_index_api v1.1.12
 	github.com/blevesearch/vellum v1.0.10
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/bits-and-blooms/bitset v1.2.0 h1:Kn4yilvwNtMACtf1eYDlG8H77R07mZSPbMjLyS07ChA=
 github.com/bits-and-blooms/bitset v1.2.0/go.mod h1:gIdJ4wp64HaoK2YrL1Q5/N7Y16edYb8uY+O0FJTyyDA=
-github.com/blevesearch/bleve_index_api v1.1.11 h1:OTNpRnxPWFIhMSgBUBlkD7RVWYrfsojtQeACb8tGGpw=
-github.com/blevesearch/bleve_index_api v1.1.11/go.mod h1:PbcwjIcRmjhGbkS/lJCpfgVSMROV6TRubGGAODaK1W8=
+github.com/blevesearch/bleve_index_api v1.1.12 h1:P4bw9/G/5rulOF7SJ9l4FsDoo7UFJ+5kexNy1RXfegY=
+github.com/blevesearch/bleve_index_api v1.1.12/go.mod h1:PbcwjIcRmjhGbkS/lJCpfgVSMROV6TRubGGAODaK1W8=
 github.com/blevesearch/mmap-go v1.0.4 h1:OVhDhT5B/M1HNPpYPBKIEJaD0F3Si+CrEKULGCDPWmc=
 github.com/blevesearch/mmap-go v1.0.4/go.mod h1:EWmEAOmdAS9z/pi/+Toxu99DnsbhG1TIxUoRmJw/pSs=
 github.com/blevesearch/vellum v1.0.10 h1:HGPJDT2bTva12hrHepVT3rOyIKFFF4t7Gf6yMxyMIPI=

--- a/vector.go
+++ b/vector.go
@@ -50,8 +50,21 @@ func (r *Reader) VectorReader(ctx context.Context, vector []float32,
 		return NewVectorFieldReaderEmpty(), nil
 	}
 
-	return NewVectorFieldReaderMatch(dims), nil
+	// searchParams not applicable for single document index
 
+	return NewVectorFieldReaderMatch(dims), nil
+}
+
+func (r *Reader) VectorReaderWithFilter(ctx context.Context, vector []float32,
+	field string, k int64, searchParams json.RawMessage,
+	filterIDs []index.IndexInternalID) (index.VectorReader, error) {
+	// if no filterIDs, current document does not qualify (in the
+	// single document index scenario)
+	if len(filterIDs) == 0 {
+		return NewVectorFieldReaderEmpty(), nil
+	}
+
+	return r.VectorReader(ctx, vector, field, k, searchParams)
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
+ If VectorReaderWithFilter has filterIDs != 1, the document is not eligible while pre-filtering.
+ Also upgrade GO version and workflows.